### PR TITLE
LPS-87553 App.bnd adaptation to bundle

### DIFF
--- a/modules/apps/headless-apio/app.bnd
+++ b/modules/apps/headless-apio/app.bnd
@@ -1,15 +1,15 @@
 Liferay-Releng-App-Description: The Liferay Hypermedia REST APIs app exposes a new breed of RESTful hypermedia APIs that interact with Liferay services. These APIs let developers consume Liferay services in a straightforward and flexible way. For example, developers can consume portal resources like sites, blogs, pages, and users via fully RESTful APIs that support several response formats like plain JSON, JSON-LD, or HAL. What's more, these APIs are evolvable and can change over time with minimal risk to most clients that consume them.<br /><br />This app has no visual component in the portal. After installing it, you can begin accessing the APIs via the home URL http://[host]:[port]/o/api.
 Liferay-Releng-App-Title: ${liferay.releng.app.title.prefix} Hypermedia REST APIs
-Liferay-Releng-Bundle: false
+Liferay-Releng-Bundle: true
 Liferay-Releng-Category: Utility
 Liferay-Releng-Demo-Url:
 Liferay-Releng-Deprecated: false
-Liferay-Releng-Fix-Delivery-Method:
+Liferay-Releng-Fix-Delivery-Method: core
 Liferay-Releng-Labs: true
 Liferay-Releng-Marketplace: true
-Liferay-Releng-Portal-Required: false
+Liferay-Releng-Portal-Required: true
 Liferay-Releng-Public: ${liferay.releng.public}
 Liferay-Releng-Restart-Required: true
-Liferay-Releng-Suite:
+Liferay-Releng-Suite: foundation
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}


### PR DESCRIPTION
If I understood it correctly, this should be the configuration to deploy headless-apis as a bundle, and should be sent it to master and backported, right?